### PR TITLE
Fix error icon not at the top of the script

### DIFF
--- a/addons/shaker/shaker.gd
+++ b/addons/shaker/shaker.gd
@@ -1,6 +1,6 @@
+@icon("res://addons/shaker/shaker.svg")
 class_name Shaker
 extends Node
-@icon("res://addons/shaker/shaker.svg")
 
 ## The node to target. Defaults to parent.
 @export var target_node: Node;


### PR DESCRIPTION
This fixes the current error: `Annotation "@icon" must be at the top of the script, before "extends" and "class_name".`